### PR TITLE
M3D-4: Take picture on actual layer change

### DIFF
--- a/prusa/link/printer_adapter/prusa_link.py
+++ b/prusa/link/printer_adapter/prusa_link.py
@@ -627,8 +627,7 @@ class PrusaLink:
         """
         prctl_name()
         log.info("Triggering photo from command")
-        # TODO: Change for the timelapse trigger
-        self.layer_trigger("")
+        self.printer.camera_controller.timestamp_shot_trigger()
 
     def fw_pause_print(self) -> None:
         """

--- a/prusa/link/printer_adapter/prusa_link.py
+++ b/prusa/link/printer_adapter/prusa_link.py
@@ -622,7 +622,7 @@ class PrusaLink:
 
     def fw_take_photo(self) -> None:
         """
-        Triggers aphoto from the camera and stores it through
+        Triggers a photo from the camera and stores it through
         another command so later a timelapse can be created
         """
         prctl_name()

--- a/prusa/link/printer_adapter/prusa_link.py
+++ b/prusa/link/printer_adapter/prusa_link.py
@@ -92,6 +92,7 @@ from .structures.regular_expressions import (
     LCD_UPDATE_REGEX,
     MBL_TRIGGER_REGEX,
     NOT_READY_REGEX,
+    TAKE_PHOTO_REGEX,
     PAUSE_PRINT_REGEX,
     POWER_PANIC_REGEX,
     PP_AUTO_RECOVER_REGEX,
@@ -209,6 +210,8 @@ class PrusaLink:
         self.printer.set_handler(CommandType.CANCEL_PRINTER_READY,
                                  self.cancel_printer_ready)
 
+        self.serial_parser.add_decoupled_handler(
+            TAKE_PHOTO_REGEX, lambda sender, match: self.fw_take_photo())
         self.serial_parser.add_decoupled_handler(
             PAUSE_PRINT_REGEX, lambda sender, match: self.fw_pause_print())
         self.serial_parser.add_decoupled_handler(
@@ -616,6 +619,16 @@ class PrusaLink:
         return self.command_queue.do_command(command)
 
     # --- FW Command handlers ---
+
+    def fw_take_photo(self) -> None:
+        """
+        Triggers aphoto from the camera and stores it through
+        another command so later a timelapse can be created
+        """
+        prctl_name()
+        log.info("Triggering photo from command")
+        # TODO: Change for the timelapse trigger
+        self.layer_trigger("")
 
     def fw_pause_print(self) -> None:
         """

--- a/prusa/link/printer_adapter/structures/regular_expressions.py
+++ b/prusa/link/printer_adapter/structures/regular_expressions.py
@@ -64,6 +64,7 @@ REJECTION_REGEX = re.compile(
 
 BUSY_REGEX = re.compile("^echo:busy: processing$")
 ATTENTION_REGEX = re.compile("^echo:busy: paused for user$")
+TAKE_PHOTO_REGEX = re.compile(r"^// ?action:photo$")
 PAUSE_PRINT_REGEX = re.compile(r"^// ?action:pause$")
 PAUSED_REGEX = re.compile(r"^// ?action:paused$")
 RESUME_PRINT_REGEX = re.compile("^// ?action:resume$")

--- a/prusa/link/sdk_augmentation/printer.py
+++ b/prusa/link/sdk_augmentation/printer.py
@@ -194,6 +194,11 @@ class MyPrinter(SDKPrinter, metaclass=MCSingleton):
         prctl_name()
         self.camera_controller.snapshot_loop()
 
+    def timelapse_shot_loop(self):
+        """Gives timelapse loop a consistent name with the rest of the app"""
+        prctl_name()
+        self.camera_controller.timelapse_shot_loop()
+
     @property
     def type_string(self):
         """Gets the string version of the printer type"""

--- a/prusa/link/sdk_augmentation/printer.py
+++ b/prusa/link/sdk_augmentation/printer.py
@@ -48,6 +48,9 @@ class MyPrinter(SDKPrinter, metaclass=MCSingleton):
         self.snapshot_thread = Thread(target=self.snapshot_loop,
                                       name="snapshot_sender",
                                       daemon=True)
+        self.timelapse_thread = Thread(target=self.timelapse_shot_loop,
+                                       name="timelapse_shot_saver",
+                                       daemon=True)
 
     def parse_command(self, res):
         """Parse telemetry response.
@@ -137,6 +140,7 @@ class MyPrinter(SDKPrinter, metaclass=MCSingleton):
         self.inotify_thread.start()
         self.download_thread.start()
         self.snapshot_thread.start()
+        self.timelapse_thread.start()
 
     def indicate_stop(self):
         """Passes the stop request to all SDK related threads.
@@ -163,6 +167,7 @@ class MyPrinter(SDKPrinter, metaclass=MCSingleton):
         self.loop_thread.join()
         self.download_thread.join()
         self.snapshot_thread.join()
+        self.timelapse_thread.join()
 
     def loop(self):
         """SDKPrinter.loop with thread name."""


### PR DESCRIPTION
Instead of right when parsing the `LAYER_CHANGE` comment from _PrusaSlicer_ generated gcode, add a listener(?) for a serial message coming from the Einsy board. This message is sent with the following gcode, which needs to be inserted at the desired spot in the gcode file.
```gcode
M118 A1 action:photo
```
> NOTE: [`M118`](https://help.prusa3d.com/article/prusa-firmware-specific-g-code-commands_112173) is a serial print command. The `A1` will prepend a `//` to the message which is usually expected by OctoPrint and PrusaLink while the final part is the triggering string that was implemented.

Saving is done in `~/prusa/timelapses/<gcode_file_name>/<gcode_file_name>_0000.jpg` and the numberin takes an ascending order based on the last number used.

> Proposed addition in PrusaSlicer for Start GCode (at the very beginning):
> ```gcode
> {global x_park_timelapse=250}
> {global y_park_timelapse=180}
> {global wait_park_timelapse=250}
> ```

> Proposed change in PrusaSlicer for After Layer Change
> ```gcode
> ;AFTER_LAYER_CHANGE
> {if wait_park_timelapse > 0}
> G1 E-{retract_length[0]*0.525} F2100
> G1 X{x_park_timelapse} Y{y_park_timelapse} F{travel_speed*60} ;Move away from the print
> G4 S0 ;Wait for move to finish
> ;TIMELAPSE_SHOT
> M118 A1 action:photo
> G4 P{wait_park_timelapse} ;Wait for {wait_park_timelapse}ms
> G1 E.{retract_length[0]*0.5} F1500
> {endif}
> ;[layer_z]
> ```